### PR TITLE
Fix 403 Forbidden errors by adding request headers

### DIFF
--- a/custom_components/idokep/api.py
+++ b/custom_components/idokep/api.py
@@ -232,8 +232,9 @@ class HttpClient:
 
             async with (
                 async_timeout.timeout(IdokepConfig.TIMEOUT),
-                self._session.get(url) as response,
+                self._session.get(url, headers=headers) as response,
             ):
+
                 response.raise_for_status()
                 return await response.text()
         except TimeoutError as exception:

--- a/custom_components/idokep/api.py
+++ b/custom_components/idokep/api.py
@@ -223,6 +223,13 @@ class HttpClient:
     async def get_html(self, url: str) -> str:
         """Get HTML content from URL with error handling."""
         try:
+            headers = {
+                "User-Agent": "Mozilla/5.0",
+                "Accept": "text/html,application/xhtml+xml",
+                "Accept-Language": "hu-HU,hu;q=0.9",
+                "Referer": "https://www.idokep.hu/"
+            }
+
             async with (
                 async_timeout.timeout(IdokepConfig.TIMEOUT),
                 self._session.get(url) as response,


### PR DESCRIPTION
Added headers to the get_html method for improved request handling.